### PR TITLE
Fix bsd-2-clause to actually have two clauses

### DIFF
--- a/template/bsd-2-clause
+++ b/template/bsd-2-clause
@@ -10,9 +10,6 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT


### PR DESCRIPTION
The template for BSD 2-clause license was actually the 3-clause license.  The third clause also had "Google, Inc." hard-coded in the text as the organization that held the copyright.

Fixed by removing the third clause.  Also, fix a typo in the file's name.