### PR TITLE
Allow setting copyright holder in .dir-locals.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ your project root directory and write follows:
 
 That means use `mit' for default license template.
 
+You can also set the copyright holder in `.dir-locals.el`. For example the
+folowing will put "John Doe" as the copyright holder:
+
+    ((nil
+      (lice:copyright-holder . "John Doe")))
+
+The default is to use `(user-full-name)`.
 
 Custom license headers
 ----------------------

--- a/lice.el
+++ b/lice.el
@@ -97,6 +97,12 @@ When nil, `comment-style' value is used."
   :safe 'stringp
   :type 'string)
 
+(defcustom lice:copyright-holder (user-full-name)
+  "The copyright holder"
+  :group 'lice
+  :safe 'stringp
+  :type 'string)
+
 (defcustom lice:header-spec '(lice:insert-copyright
                               lice:insert-license)
   "The license header spec.
@@ -168,7 +174,7 @@ NAME is a template name for insertion."
 
 (defun lice:insert-copyright (license)
   (insert (format "Copyright (C) %s  %s\n\n"
-                  (format-time-string "%Y") (user-full-name))))
+                  (format-time-string "%Y")  lice:copyright-holder)))
 
 (defun lice:insert-license (license)
   (insert-file-contents (cdr license)))


### PR DESCRIPTION
The default is still (user-full-name). But now it can be customized, and
more importantly it can be overridden in .dir-locals.el.
This might be useful if you are working in a project where you want to
assign copyright to a project or team or such.
