### PR TITLE
Clean up read-license prompt

### DIFF
--- a/lice.el
+++ b/lice.el
@@ -180,7 +180,7 @@ NAME is a template name for insertion."
   (insert-file-contents (cdr license)))
 
 (defun lice:read-license ()
-  (completing-read (format "License Name (%s): " lice:default-license)
+  (completing-read "License Name: "
                    (lice:licenses)
                    nil t nil 'lice:license-history
                    lice:default-license))


### PR DESCRIPTION
At the moment, `read-license` prompt suggests default license right in the
prompt.  This is excessive.  Default license is already accounted for
in DEF argument to `completing-read`.